### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,4 +1,6 @@
 name: Gradle Build
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/rahulsom/yamlego/security/code-scanning/1](https://github.com/rahulsom/yamlego/security/code-scanning/1)

The fix is to add an explicit `permissions` key to the workflow. This can be done at the top (root) level, which will apply to all jobs (including reusable workflow calls), or at the individual job level. The safest and recommended minimal permission is `contents: read` except if the workflow needs to write to the repository or perform other operations (which are uncommon for build jobs). In this case, since this is a build job likely only requiring basic repository access, add:

```yaml
permissions:
  contents: read
```

right after the workflow `name` and before `on` for root-level application. If more granular access is needed (e.g., for publishing releases, creating PRs), the permissions block can be expanded, but the provided context does not indicate such a need.

The change should be made at the top of `.github/workflows/gradle.yml`, after `name:` and before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
